### PR TITLE
Bugfix: Treat text content as optional when computing node name

### DIFF
--- a/src/AOM/utils.ts
+++ b/src/AOM/utils.ts
@@ -45,7 +45,7 @@ export function trimStart(el: AOMElement[]) {
     const isText = el[i]!.role === "text";
     const textElement = el[i] as TextElement;
 
-    if (isText && textElement.text.trimStart() !== "") {
+    if (isText && textElement.text?.trimStart() !== "") {
       const trimmedTextElement = new TextElement({
         node: textElement.domNode,
         key: textElement.key,

--- a/src/view/renderers/render.ts
+++ b/src/view/renderers/render.ts
@@ -106,7 +106,7 @@ export default function render(element: AOMElement | AOMElement[]): any {
 
   if (element.role === "text") {
     const textNode = element as TextElement;
-    return textNode.text.trim() ? React.createElement(Text, { node: textNode, key: textNode.key }) : textNode.text;
+    return textNode.text?.trim() ? React.createElement(Text, { node: textNode, key: textNode.key }) : textNode.text;
   }
 
   const node = element as NodeElement;


### PR DESCRIPTION
## Why
There are some occasions where the `textElement.text` may be undefined, resulting in the bug seen in #21.

## What
- [x] fixes the bug by treating the `.text` field as optional in conditional logic before attempting to trim it

## Details

Logic like `getAccessibleNameOf()` [here](https://github.com/ziolko/aria-devtools/blob/e28b6234582feac265638f99b993828ad3dd75a9/src/AOM/types.ts#L458-L465) seem to imply that the text field shouldn't be optional. I'm not exactly sure what the root cause making `textElement.text === undefined` actually is.

If it's not supposed to be optional, this patch doesn't solve the root cause.

---

fixes #21 