### PR TITLE
Better handle click events.

### DIFF
--- a/src/view/renderers/Button.tsx
+++ b/src/view/renderers/Button.tsx
@@ -1,6 +1,13 @@
 import styled from "styled-components";
 import React, {useRef} from "react";
-import {borderRadius, hoveredBoxShadow, renderContext, selectedBoxShadow, useFocusable} from "./utils";
+import {
+  borderRadius,
+  hoveredBoxShadow,
+  renderContext,
+  selectedBoxShadow,
+  useFocusable,
+  useClick,
+} from "./utils";
 import { ComponentProps } from "./utils";
 import { observer } from "mobx-react";
 import { BlockTemplate } from "./Block";
@@ -55,6 +62,7 @@ const SimpleButton = observer(function SimpleButton({ node }: ComponentProps) {
   const [ref, style] = useFocusable(node);
   const roleRef = useRef<HTMLSpanElement>(null);
   const openSidePanel = useOpenSidePanel();
+  const onClick = useClick(node);
 
   return (
     <SimpleButtonWrapper
@@ -65,7 +73,7 @@ const SimpleButton = observer(function SimpleButton({ node }: ComponentProps) {
       isPressed={!!node.attributes.ariaPressed}
       onClick={(event) => {
         if(!roleRef.current?.isEqualNode(event.target as any)) {
-            node.domNode.click()
+            onClick(event)
         }
       }}
     >

--- a/src/view/renderers/Checkbox.tsx
+++ b/src/view/renderers/Checkbox.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import React from "react";
-import { borderRadius, useFocusable } from "./utils";
+import { borderRadius, useClick, useFocusable } from "./utils";
 import { ComponentProps } from "./utils";
 import { observer } from "mobx-react";
 
@@ -43,9 +43,14 @@ const RadioLabel = styled.span`
 export default observer(function Checkbox({ node }: ComponentProps) {
   const [isHovered, setHovered] = React.useState(false);
   const [ref, style] = useFocusable(node);
+  const onClick = useClick(node);
 
   return (
-    <CheckboxWrapper isHovered={isHovered} ref={ref} style={style}>
+    <CheckboxWrapper
+      isHovered={isHovered}
+      ref={ref}
+      style={style}
+      onClick={onClick}>
       <CheckboxIcon
         onMouseOver={() => setHovered(true)}
         onMouseOut={() => setHovered(false)}

--- a/src/view/renderers/Link.tsx
+++ b/src/view/renderers/Link.tsx
@@ -7,6 +7,7 @@ import {
     IssuesBadge,
     renderContext,
     selectedBoxShadow,
+    useClick,
     useFocusable
 } from "./utils";
 import {observer} from "mobx-react";
@@ -54,6 +55,7 @@ export default observer(function Link({node}: ComponentProps) {
     const render = React.useContext(renderContext);
     const [isHovered, setHovered] = React.useState(false);
     const [ref, style] = useFocusable(node);
+    const onClick = useClick(node);
     const openSidePanel = useOpenSidePanel();
 
     const children = trimStart(node.children) ?? [];
@@ -75,7 +77,7 @@ export default observer(function Link({node}: ComponentProps) {
                 🔗
                 <IssuesBadge node={node}/>
             </Role>
-            <LinkContent onClick={(event) => !event.defaultPrevented && node.domNode.click()}>
+            <LinkContent onClick={onClick}>
                 {getContent()}
             </LinkContent>
         </LinkWrapper>

--- a/src/view/renderers/Radio.tsx
+++ b/src/view/renderers/Radio.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import React from "react";
-import { borderRadius, useFocusable } from "./utils";
+import { borderRadius, useClick, useFocusable } from "./utils";
 import { ComponentProps } from "./utils";
 import { observer } from "mobx-react";
 
@@ -43,12 +43,14 @@ const RadioLabel = styled.span`
 export default observer(function Radio({ node }: ComponentProps) {
   const [isHovered, setHovered] = React.useState(false);
   const [ref, style] = useFocusable(node);
+  const onClick = useClick(node);
 
   return (
     <RadioButtonWrapper isHovered={isHovered} ref={ref} style={style}>
       <RadioIcon
         onMouseOver={() => setHovered(true)}
         onMouseOut={() => setHovered(false)}
+        onClick={onClick}
         checked={!!node.attributes.htmlChecked || node.attributes.ariaChecked === 'true'}
       />
       <RadioLabel>{node.accessibleName}</RadioLabel>

--- a/src/view/renderers/utils.tsx
+++ b/src/view/renderers/utils.tsx
@@ -55,6 +55,16 @@ export function useFocusable(node: NonNullable<NodeElement>): [React.Ref<any>, o
   return [ref, style];
 }
 
+export function useClick(node: NonNullable<NodeElement>): (event: React.MouseEvent) => void {
+  return React.useCallback((event) => {
+      if (event.defaultPrevented) {
+          return;
+      }
+      node.domNode.focus();
+      node.domNode.click();
+  }, [node]);
+}
+
 export function scrollToElement(element: Element) {
   const scrollParent = element.getRootNode()?.getElementById("aria-dev-tools-scroll-parent");
   if (!scrollParent) {


### PR DESCRIPTION
This makes the use of the mouse in ARIA-mode more
consistant with the regular use of the mouse: first focus on
an element before triggering onClick.