### PR TITLE
Fix table footers: correct tfoot tag name

### DIFF
--- a/src/AOM/types.ts
+++ b/src/AOM/types.ts
@@ -153,7 +153,7 @@ export class HtmlTableContext {
     @computed get rows(): NodeElement[][] {
         const result = new Table();
 
-        const rowNodes = this.getNodes(this.root, "tr", "tbody", "tfooter", "thead")
+        const rowNodes = this.getNodes(this.root, "tr", "tbody", "tfoot", "thead")
             .map(node => (node.htmlTag === "tr" ? node : this.getNodes(node, "tr")))
             .flat();
 


### PR DESCRIPTION
There is no `<tfooter>` tag, only `<tfoot>`. This PR fixes the name to make table footers show up in tables.