### PR TITLE
Add support for progressbar role

### DIFF
--- a/src/AOM/types.ts
+++ b/src/AOM/types.ts
@@ -405,6 +405,7 @@ export type AriaRole =
     | "main"
     | "navigation"
     | "paragraph"
+    | "progressbar"
     | "region"
     | "row"
     | "rowgroup"
@@ -484,6 +485,7 @@ export class RawNodeAttributes {
     @observable scope?: string = undefined;
     @observable min?: string = undefined;
     @observable max?: string = undefined;
+    @observable value?: string = undefined;
 
     @observable "aria-activedescendant"?: HtmlID = undefined;
     @observable "aria-atomic"?: boolean = undefined;
@@ -773,6 +775,16 @@ export class Aria {
 
         if (htmlTag === "svg") {
             return {role: "graphics-document"};
+        }
+
+        if (htmlTag === "progress") {
+            return {
+                role: "progressbar",
+                // https://w3c.github.io/aria/#progressbar
+                ariaValueMin: 0,
+                ariaValueMax: this.rawAttributes.max ?? 100,
+                ariaValueNow: this.rawAttributes.value
+            };
         }
 
         if (htmlTag === "table") {

--- a/src/view/renderers/ProgressBar.tsx
+++ b/src/view/renderers/ProgressBar.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { HorizontalBlockTemplate } from "./Heading";
+import { HeaderTag} from "./Tab";
+import { renderContext, ComponentProps } from "./utils";
+import { observer } from "mobx-react";
+
+export default observer(function ProgressBar({ node }: ComponentProps) {
+  const render = React.useContext(renderContext);
+  const value = node.attributes.ariaValueMax
+    ? `${node.attributes.ariaValueNow}/${node.attributes.ariaValueMax}`
+    : node.attributes.ariaValueNow
+
+  const header = (
+      <>
+          {node.role}
+          <HeaderTag isVisible={node.attributes.ariaValueNow}>[{value}]</HeaderTag>
+      </>
+  );
+
+  return (
+    <HorizontalBlockTemplate header={header} node={node}>
+      {render(node.children)}
+    </HorizontalBlockTemplate>
+  );
+});

--- a/src/view/renderers/render.ts
+++ b/src/view/renderers/render.ts
@@ -29,6 +29,7 @@ import Tab from "./Tab";
 import TabPanel from "./TabPanel";
 import Invalid from "./Invalid";
 import Details from "./Details";
+import ProgressBar from "./ProgressBar";
 
 type RendererMap = { [key in string]: React.FunctionComponent<ComponentProps> };
 
@@ -95,6 +96,7 @@ const renderers: RendererMap = {
   marquee: Block,
   timer: Block,
   spinbutton: TextBox,
+  progressbar: ProgressBar,
 };
 
 const htmlTagRenderers: RendererMap = {

--- a/test/aria-mapping.test.tsx
+++ b/test/aria-mapping.test.tsx
@@ -355,4 +355,23 @@ describe("HTML-ARIA mappings", () => {
     const { AOM } = sandbox(<summary id="result" />);
     expect(AOM.result.role).to.be.equal("button");
   });
+
+  it("Should map progress to progressbar", () => {
+    const { AOM } = sandbox(
+      <div>
+        <progress id="progress1" value="5" />
+        <progress id="progress2" max="10" value="5" />
+      </div>
+    );
+
+    expect(AOM.progress1.role).to.be.equal("progressbar");
+    expect(AOM.progress1.attributes.ariaValueMin).to.be.equal(0);
+    expect(AOM.progress1.attributes.ariaValueMax).to.be.equal(100);
+    expect(AOM.progress1.attributes.ariaValueNow).to.be.equal(5);
+
+    expect(AOM.progress2.role).to.be.equal("progressbar");
+    expect(AOM.progress2.attributes.ariaValueMin).to.be.equal(0);
+    expect(AOM.progress2.attributes.ariaValueMax).to.be.equal(10);
+    expect(AOM.progress2.attributes.ariaValueNow).to.be.equal(5);
+  });
 });


### PR DESCRIPTION
I had a go at implementing support for the `progressbar` role following the comments in https://github.com/ziolko/aria-devtools/pull/45#issuecomment-1795688014 in order to fix #27. This adds support for:

* `<progress>` element (including `max` and `value` attributes)
* Elements with the `progressbar` role (including `aria-valuenow` and `aria-valuemax` attributes)

I wasn't sure the best way to render it, so I tried to use existing render patterns:

<img width="732" height="772" alt="Screenshot 2026-01-11 at 9 14 09 PM" src="https://github.com/user-attachments/assets/a71f4cf5-66f4-4a30-a561-f3c5a7df98e2" />

@ziolko please let me know if there's anything else I need to do.
