### PR TITLE
Traverse slotted shadow DOM content via assigned nodes

### DIFF
--- a/src/AOM/traverse.ts
+++ b/src/AOM/traverse.ts
@@ -3,6 +3,22 @@ import {getNodeKey} from "./utils";
 
 const ignoredHtmlElements = ["script", "noscript", "style"];
 
+// Follows the flattened (composed) tree, like the browser's accessibility tree:
+// a shadow host exposes its shadow root, a <slot> exposes its assigned nodes
+// (or its fallback children when nothing is slotted), everything else its light DOM.
+function getTraversableChildNodes(node: HTMLElement): Iterable<Node> {
+    if (node.shadowRoot != null) {
+        return node.shadowRoot.childNodes;
+    }
+
+    if (node instanceof HTMLSlotElement) {
+        const assigned = node.assignedNodes();
+        return assigned.length > 0 ? assigned : node.childNodes;
+    }
+
+    return node.childNodes;
+}
+
 export default function traverse(htmlNode: Node, traversedNodes = new Map<Node, AOMElement>()): AOMElement {
     if (traversedNodes.has(htmlNode)) {
         return traversedNodes.get(htmlNode);
@@ -40,10 +56,10 @@ export default function traverse(htmlNode: Node, traversedNodes = new Map<Node, 
     // @ts-ignore
     properties.invalid = node.validity ? !node.validity.valid : undefined;
 
-    const children = node.shadowRoot == null ? node.childNodes : node.shadowRoot.childNodes;
+    const children = getTraversableChildNodes(node);
 
-    children.forEach(subNOde => {
-        const child = traverse(subNOde, traversedNodes);
+    Array.from(children).forEach(subNode => {
+        const child = traverse(subNode, traversedNodes);
         if (child) {
             child.htmlParent = result;
             result.htmlChildren.push(child);

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,6 +5,7 @@ mocha.setup("bdd");
 
 require('./aria-mapping.test')
 require("./dynamic-html.test");
+require("./shadow-dom.test");
 require("./accessible-name.test");
 require("./relations.test");
 require("./tables.test");

--- a/test/shadow-dom.test.tsx
+++ b/test/shadow-dom.test.tsx
@@ -1,0 +1,142 @@
+import { expect } from "chai";
+import traverse from "../src/AOM/traverse";
+import Observer from "../src/store/observer";
+import { getNodeKey } from "../src/AOM/utils";
+import { NodeElement, TextElement } from "../src/AOM/types";
+
+type AnyEl = NodeElement | TextElement;
+
+// Shadow roots are attached to plain <div>s (no custom elements) so the tests
+// don't depend on class-to-ES5 transpilation of HTMLElement subclasses.
+describe("Shadow DOM / slots", () => {
+  const mounted: HTMLElement[] = [];
+
+  afterEach(() => {
+    while (mounted.length) mounted.pop()!.remove();
+  });
+
+  function mount(el: HTMLElement) {
+    document.body.appendChild(el);
+    mounted.push(el);
+    return el;
+  }
+
+  function host(shadowHtml: string, lightHtml: string): HTMLElement {
+    const el = document.createElement("div");
+    el.attachShadow({ mode: "open" }).innerHTML = shadowHtml;
+    el.innerHTML = lightHtml;
+    return el;
+  }
+
+  function flatten(node: AnyEl | null | undefined): AnyEl[] {
+    const out: AnyEl[] = [];
+    const walk = (n: AnyEl | null | undefined) => {
+      if (!n) return;
+      out.push(n);
+      if (n instanceof NodeElement) n.htmlChildren.forEach(walk);
+    };
+    walk(node);
+    return out;
+  }
+
+  const ids = (node: AnyEl) =>
+    flatten(node)
+      .filter((x): x is NodeElement => x instanceof NodeElement)
+      .map(x => x.domNode.id)
+      .filter(Boolean);
+
+  const tags = (node: AnyEl) =>
+    flatten(node)
+      .filter((x): x is NodeElement => x instanceof NodeElement)
+      .map(x => x.htmlTag);
+
+  const texts = (node: AnyEl) =>
+    flatten(node)
+      .filter((x): x is TextElement => x instanceof TextElement)
+      .map(x => x.text.trim())
+      .filter(Boolean);
+
+  it("Should surface slotted light-DOM content assigned to a default slot", () => {
+    const el = mount(
+      host(`<div class="card-shell"><slot></slot></div>`, `<button id="slotted-button">Slotted</button>`)
+    );
+
+    const tree = traverse(el) as NodeElement;
+
+    expect(tags(tree)).to.include("div");
+    expect(ids(tree)).to.include("slotted-button");
+    expect(texts(tree)).to.include("Slotted");
+  });
+
+  it("Should render slot fallback content when nothing is assigned", () => {
+    const el = mount(host(`<slot><span id="fb">fallback content</span></slot>`, ``));
+
+    const tree = traverse(el) as NodeElement;
+
+    expect(ids(tree)).to.include("fb");
+    expect(texts(tree)).to.include("fallback content");
+  });
+
+  it("Should resolve named slots and the default slot independently", () => {
+    const el = mount(
+      host(
+        `<slot name="title"></slot><div class="body"><slot></slot></div>`,
+        `<h2 id="title" slot="title">The title</h2><p id="body">The body</p>`
+      )
+    );
+
+    const tree = traverse(el) as NodeElement;
+
+    expect(ids(tree)).to.include("title");
+    expect(ids(tree)).to.include("body");
+    expect(texts(tree)).to.include("The title");
+    expect(texts(tree)).to.include("The body");
+  });
+
+  it("Should follow slots across nested shadow roots", () => {
+    // Mirrors <swiper-container><swiper-slide>…</swiper-slide></swiper-container>:
+    // an outer host that slots in an inner host that slots in the real content.
+    const inner = host(`<div class="slide-shell"><slot></slot></div>`, `<a id="deep-link" href="#">Deep link</a>`);
+    inner.id = "inner";
+
+    const outer = document.createElement("div");
+    outer.attachShadow({ mode: "open" }).innerHTML = `<div class="wrapper"><slot></slot></div>`;
+    outer.appendChild(inner);
+    mount(outer);
+
+    const tree = traverse(outer) as NodeElement;
+
+    expect(ids(tree)).to.include("deep-link");
+    expect(ids(tree).filter(id => id === "inner").length, "traversed once").to.equal(1);
+    expect(ids(tree).filter(id => id === "deep-link").length, "traversed once").to.equal(1);
+    expect(texts(tree)).to.include("Deep link");
+  });
+
+  it("Should react to slotted content being added dynamically", async () => {
+    const container = document.createElement("div");
+    const slideHost = host(`<div class="shell"><slot></slot></div>`, `<button id="first">First</button>`);
+    container.appendChild(slideHost);
+    mount(container);
+
+    const observer = new Observer(container);
+    try {
+      const buttonIds = () => {
+        const root = observer.store.getElement(getNodeKey(container)) as NodeElement;
+        return ids(root).filter(id => id === "first" || id === "second");
+      };
+
+      expect(buttonIds()).to.deep.equal(["first"]);
+
+      const second = document.createElement("button");
+      second.id = "second";
+      second.textContent = "Second";
+      slideHost.appendChild(second);
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(buttonIds()).to.deep.equal(["first", "second"]);
+    } finally {
+      observer.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

We are using Swiper for slideshows. And Swiper uses shadow DOM and slots, which this chrome extension does not support/not recognize. This was already previously mentioned in #52. This PR fixes this.

For testing it with swiper: The slides only appear if there is an a11y relevant element in them, e.g. an image with alt text.

Builds the accessibility tree from the flattened (composed) shadow DOM tree so slotted content is no longer dropped.

`traverse()` now picks an element's children via a small helper:

- a shadow host → its shadow root's content
- a `<slot>` → its `assignedNodes()` (or its own children as fallback when nothing is slotted)
- any other element → its light DOM

Recursion handles nesting (a slotted node that is itself a shadow host, or slots forwarded into slots), so plain `assignedNodes()` is sufficient.

## Why

Previously an open shadow root was traversed but `<slot>` assignment was ignored, so slotted light-DOM content was missing from the tree. This is visible on real components such as Swiper Element (`<swiper-container>` slots in `<swiper-slide>`s, each of which slots in its own content): the slide content never appeared. Light-DOM-only pages are unaffected — they take the same `childNodes` path as before.